### PR TITLE
Some improvements to channel merging

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -189,8 +189,7 @@ def merge_color_channels(im_list, color_list=None,
         containing the merged RGB data
 
     """
-    # TODO: Use color_cycler from matplotlib to prevent limit to number of
-    #  images
+    # TODO: Can itertools.cycle be used here to remove the 6 image limit?
     color_cycle = ['red', 'green', 'blue', 'cyan', 'yellow', 'magenta']
     if len(im_list) > 6:
         raise ValueError('List must be at most 6 images long')
@@ -200,8 +199,16 @@ def merge_color_channels(im_list, color_list=None,
         raise ValueError("Invalid color. Only red, green, blue, cyan, yellow "
                          "and magenta allowed")
 
-    # TODO: check to ensure that all images are same shape - error if not
-    height, width = im_list[0].data.shape[:2]
+    # shapes is (N, 2) numpy array containing the height and width of each image
+    shapes = np.asarray([im.data.shape[:2] for im in im_list])
+    # Compare all rows of shapes to first row, and check if all rows in each
+    # column are identical
+    isequal = np.all(shapes == shapes[0, :], axis=0)
+    # isequal should be [True, True], if it's not, raise an error:
+    if not np.all(isequal):
+        raise ValueError("All images must be the same shape to build "
+                         "composite. Image shapes were: \n{}".format(shapes))
+    height, width = shapes[0, :]
 
     images = dict()
     images['rgb'] = np.zeros([height, width, 3])

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -185,6 +185,8 @@ def merge_color_channels(im_list, color_list=None,
         containing the merged RGB data
 
     """
+    # TODO: Use color_cycler from matplotlib to prevent limit to number of
+    #  images
     color_cycle = ['red', 'green', 'blue', 'cyan', 'yellow', 'magenta']
     if len(im_list) > 6:
         raise ValueError('List must be at most 6 images long')
@@ -193,7 +195,8 @@ def merge_color_channels(im_list, color_list=None,
     if not all(x in color_cycle for x in color_list):
         raise ValueError("Invalid color. Only red, green, blue, cyan, yellow "
                          "and magenta allowed")
-    
+
+    # TODO: check to ensure that all images are same shape - error if not
     height, width = im_list[0].data.shape[:2]
 
     images = dict()

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -158,7 +158,8 @@ def key_press_handler_custom(event, canvas):
 
 
 def merge_color_channels(im_list, color_list=None,
-                         normalization='single', plot=True):
+                         normalization='single', plot=True,
+                         legend=None):
     """
     Merge up to six gray scale images into a color composite.
 
@@ -177,6 +178,9 @@ def merge_color_channels(im_list, color_list=None,
         results of the merged images in addition to returning the merged RGB
         matrix; if False, the method will silently return the RGB matrix
         without plotting.
+    legend : None or list of str
+        Legend for each color to include in the plotted output. Should be one
+        string for each image in ``im_list``
 
     Returns
     -------
@@ -262,6 +266,12 @@ def merge_color_channels(im_list, color_list=None,
         ax.frameon = False
         ax.set_axis_off()
         ax.imshow(images['rgb'], interpolation='nearest')
+
+        if legend is not None:
+            # TODO: add a legend capability (as you'd have with elemental maps,
+            #  for instance)
+            pass
+
         figure.canvas.draw_idle()
         return figure, images
     else:

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -172,6 +172,11 @@ def merge_color_channels(im_list, color_list=None,
         Either 'single' or 'global'; controls whether the color scales are
         normalized on a per-image basis (``'single'``), or globally over all
         images (``'global'``)
+    plot : bool
+        Controls plotting output. If True (default), the method will plot the
+        results of the merged images in addition to returning the merged RGB
+        matrix; if False, the method will silently return the RGB matrix
+        without plotting.
 
     Returns
     -------
@@ -259,12 +264,12 @@ def merge_color_channels(im_list, color_list=None,
                                  "yellow, magenta, or cyan.")
         else:
             raise ValueError("Unknown normalization method."
-                             "Must be 'individual' or 'global'.")
+                             "Must be 'single' or 'global'.")
 
     for i in color_list:
         images['rgb'] += images[i]
 
-    if not dont_plot:
+    if plot:
         figure = plt.figure()
         ax = figure.add_subplot(111)
         ax.frameon = False

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -235,8 +235,8 @@ def merge_color_channels(im_list, color_list=None,
                                  "yellow, magenta, or cyan")
         elif normalization == 'global':
             maxvals = np.zeros(len(im_list))
-            for i in range(0, len(im_list)):
-                maxvals[i] = im_list[i].data.max()
+            for im_num in range(0, len(im_list)):
+                maxvals[im_num] = im_list[im_num].data.max()
             maxval = maxvals.max()
             if color_list[i] == 'red':
                 images['red'][:, :, 0] = \

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -204,70 +204,54 @@ def merge_color_channels(im_list, color_list=None,
     for i in color_list:
         images[i] = np.zeros([height, width, 3])
 
-    for i in range(0, len(im_list)):
-        if normalization == 'single':
-            if color_list[i] == 'red':
-                images['red'][:, :, 0] = \
-                    im_list[i].data/im_list[i].data.max()
-            elif color_list[i] == 'green':
-                images['green'][:, :, 1] = \
-                    im_list[i].data/im_list[i].data.max()
-            elif color_list[i] == 'blue':
-                images['blue'][:, :, 2] = \
-                    im_list[i].data/im_list[i].data.max()
-            elif color_list[i] == 'yellow':
-                images['yellow'][:, :, 0] = \
-                    im_list[i].data/im_list[i].data.max()
-                images['yellow'][:, :, 1] = \
-                    im_list[i].data/im_list[i].data.max()
-            elif color_list[i] == 'magenta':
-                images['magenta'][:, :, 0] = \
-                    im_list[i].data/im_list[i].data.max()
-                images['magenta'][:, :, 2] = \
-                    im_list[i].data/im_list[i].data.max()
-            elif color_list[i] == 'cyan':
-                images['cyan'][:, :, 1] = \
-                    im_list[i].data/im_list[i].data.max()
-                images['cyan'][:, :, 2] = \
-                    im_list[i].data/im_list[i].data.max()
-            else:
-                raise ValueError("Unknown color. Must be red, green, blue, "
-                                 "yellow, magenta, or cyan")
-        elif normalization == 'global':
+    def _normalize_channels(im_list, color_list, method, iter_number):
+        # determine normalization denominator
+        if method == 'single':
+            norm_value = im_list[iter_number].data.max()
+        elif method == 'global':
             maxvals = np.zeros(len(im_list))
             for im_num in range(0, len(im_list)):
                 maxvals[im_num] = im_list[im_num].data.max()
             maxval = maxvals.max()
-            if color_list[i] == 'red':
-                images['red'][:, :, 0] = \
-                    im_list[i].data/maxval
-            elif color_list[i] == 'green':
-                images['green'][:, :, 1] = \
-                    im_list[i].data/maxval
-            elif color_list[i] == 'blue':
-                images['blue'][:, :, 2] = \
-                    im_list[i].data/maxval
-            elif color_list[i] == 'yellow':
-                images['yellow'][:, :, 0] = \
-                    im_list[i].data/maxval
-                images['yellow'][:, :, 1] = \
-                    im_list[i].data/maxval
-            elif color_list[i] == 'magenta':
-                images['magenta'][:, :, 0] = \
-                    im_list[i].data/maxval
-                images['magenta'][:, :, 2] = \
-                    im_list[i].data/maxval
-            elif color_list[i] == 'cyan':
-                images['cyan'][:, :, 1] = \
-                    im_list[i].data/maxval
-                images['cyan'][:, :, 2] = \
-                    im_list[i].data/maxval
-            else:
-                raise ValueError("Unknown color. Must be red, green, blue, "
-                                 "yellow, magenta, or cyan.")
+            norm_value = maxval
         else:
             raise ValueError("Unknown normalization method."
                              "Must be 'single' or 'global'.")
+
+        if color_list[iter_number] == 'red':
+            images['red'][:, :, 0] = \
+                im_list[iter_number].data / norm_value  # red channel
+        elif color_list[iter_number] == 'green':
+            images['green'][:, :, 1] = \
+                im_list[iter_number].data / norm_value  # green channel
+        elif color_list[iter_number] == 'blue':
+            images['blue'][:, :, 2] = \
+                im_list[iter_number].data / norm_value  # blue channel
+        elif color_list[iter_number] == 'yellow':
+            images['yellow'][:, :, 0] = \
+                im_list[iter_number].data / norm_value  # red channel +
+            images['yellow'][:, :, 1] = \
+                im_list[iter_number].data / norm_value  # green channel
+        elif color_list[iter_number] == 'magenta':
+            images['magenta'][:, :, 0] = \
+                im_list[iter_number].data / norm_value  # red channel +
+            images['magenta'][:, :, 2] = \
+                im_list[iter_number].data / norm_value  # blue channel
+        elif color_list[iter_number] == 'cyan':
+            images['cyan'][:, :, 1] = \
+                im_list[iter_number].data / norm_value  # green channel +
+            images['cyan'][:, :, 2] = \
+                im_list[iter_number].data / norm_value  # blue channel
+        else:
+            raise ValueError("Unknown color. Must be red, green, blue, "
+                             "yellow, magenta, or cyan.")
+
+    # TODO: check how ImageJ does this (it's probably the same)
+    #  https://imagej.nih.gov/ij/developer/source/ij/plugin/RGBStackMerge.java.html
+    #  ImageJ also includes a grayscale image
+    for i in range(0, len(im_list)):
+        # TODO: move normalization into function
+        _normalize_channels(im_list, color_list, normalization, i)
 
     for i in color_list:
         images['rgb'] += images[i]

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -156,20 +156,28 @@ def key_press_handler_custom(event, canvas):
     if event.key not in ['k', 'l', 'L']:
         key_press_handler(event, canvas, canvas.manager.toolbar)
 
+
 def merge_color_channels(im_list, color_list=None,
-                         normalization='single', dont_plot=False):
-    """Merge up to six gray scale images into color composite.
+                         normalization='single', plot=True):
+    """
+    Merge up to six gray scale images into a color composite.
 
     Parameters
     ----------
-    im_list : list of Signal2D instances
-    color_list : list of color strings
-    normalization : {'single', 'global'}
-    dont_plot : bool
+    im_list : list of Signal2D instances (images) to be merged
+    color_list : list of strings
+        Should be valid matplotlib color strings, such as 'red', 'green',
+        'blue, etc.
+    normalization : str
+        Either 'single' or 'global'; controls whether the color scales are
+        normalized on a per-image basis (``'single'``), or globally over all
+        images (``'global'``)
 
     Returns
     -------
     array: RGB matrix
+        A numpy array (same width and height as images) with three channels
+        containing the merged RGB data
 
     """
     color_cycle = ['red', 'green', 'blue', 'cyan', 'yellow', 'magenta']
@@ -183,7 +191,7 @@ def merge_color_channels(im_list, color_list=None,
     
     height, width = im_list[0].data.shape[:2]
 
-    images = {}
+    images = dict()
     images['rgb'] = np.zeros([height, width, 3])
     for i in color_list:
         images[i] = np.zeros([height, width, 3])
@@ -266,6 +274,7 @@ def merge_color_channels(im_list, color_list=None,
         return figure, images
     else:
         return images
+
 
 def on_figure_window_close(figure, function):
     """Connects a close figure signal to a given function.


### PR DESCRIPTION
As per email:

- Fixed a bug in the global normalization (variable "i" was being used twice in a nested loop)
- Added check for if images are all the same size
- Made some changes to docstrings and such - also modified some things to be PEP8 compliant
- Changed "dont_plot" to "plot", since that's a more natural comparison
- Moved normalization code into its own method to reduce duplication of code

I'd still like todo:
- [ ] At least a simple legend where you can map colors to a text label
- [ ] Looking into using itertools.cycle (like the other plotting methods) so we don't have to limit the code to six images
- [ ] In ImageJ, you can also include a "grayscale" image, which I think is helpful when coloring SEM images, for instance (assuming they're all the same resolution). That could be a nice feature to include.